### PR TITLE
fix: 天地图使用random函数随机一个子域区间值

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -728,9 +728,9 @@
       "dev": true
     },
     "cesium": {
-      "version": "1.70.1",
-      "resolved": "https://registry.npm.taobao.org/cesium/download/cesium-1.70.1.tgz",
-      "integrity": "sha1-LJ9FdFXzDj+0TOnDhbyb002vjqQ=",
+      "version": "1.86.0",
+      "resolved": "https://registry.npmjs.org/cesium/-/cesium-1.86.0.tgz",
+      "integrity": "sha512-F3asFdI49opQhoAO7XY2yF0xuVDKdfqEHlBveEX5ioX63iWikOP/H4ih04wbm1ijqBYCljOp01yXUf4tztWFbw==",
       "dev": true
     },
     "chalk": {

--- a/src/TianDiTu.ts
+++ b/src/TianDiTu.ts
@@ -4,7 +4,7 @@
  * @see {@link http://lbs.tianditu.gov.cn/server/MapService.html docs}
  */
 import { WebMapTileServiceImageryProvider } from 'cesium'
-
+// !由于WebMapTileServiceImageryProvider使用{s}占位符后其他参数请求时丢失, 临时使用random函数随机一个子域区间值
 /**
  * Vector streets Image - 矢量道路图地图
  * - Spherical Mercator projection（球面墨卡托投影）
@@ -16,7 +16,7 @@ import { WebMapTileServiceImageryProvider } from 'cesium'
  */
 function streetsMap({ token, options }: { token: string; options?: WebMapTileServiceImageryProvider.ConstructorOptions }): WebMapTileServiceImageryProvider {
 	return new WebMapTileServiceImageryProvider({
-		url: `http://t0.tianditu.com/vec_w/wmts?tk=${token}`,
+		url: `http://t${(Math.random() * (7 - 0 + 1) + 0) | 0}.tianditu.gov.cn/vec_w/wmts?tk=${token}`,
 		format: 'tiles',
 		layer: 'vec',
 		style: 'default',
@@ -44,7 +44,7 @@ function streetsAnnotation({
 	options?: WebMapTileServiceImageryProvider.ConstructorOptions
 }): WebMapTileServiceImageryProvider {
 	return new WebMapTileServiceImageryProvider({
-		url: `http://t0.tianditu.com/cva_w/wmts?tk=${token}`,
+		url: `http://t${(Math.random() * (7 - 0 + 1) + 0) | 0}.tianditu.gov.cn/cva_w/wmts?tk=${token}`,
 		format: 'tiles',
 		layer: 'cva',
 		style: 'default',
@@ -66,7 +66,7 @@ function streetsAnnotation({
  */
 function satelliteMap({ token, options }: { token: string; options?: WebMapTileServiceImageryProvider.ConstructorOptions }): WebMapTileServiceImageryProvider {
 	return new WebMapTileServiceImageryProvider({
-		url: `http://t0.tianditu.com/img_w/wmts?tk=${token}`,
+		url: `http://t${(Math.random() * (7 - 0 + 1) + 0) | 0}.tianditu.gov.cn/img_w/wmts?tk=${token}`,
 		format: 'tiles',
 		layer: 'img',
 		style: 'default',
@@ -94,7 +94,7 @@ function satelliteAnnotation({
 	options?: WebMapTileServiceImageryProvider.ConstructorOptions
 }): WebMapTileServiceImageryProvider {
 	return new WebMapTileServiceImageryProvider({
-		url: `http://t0.tianditu.com/cia_w/wmts?tk=${token}`,
+		url: `http://t${(Math.random() * (7 - 0 + 1) + 0) | 0}.tianditu.gov.cn/cia_w/wmts?tk=${token}`,
 		format: 'tiles',
 		layer: 'cia',
 		style: 'default',

--- a/test/index.html
+++ b/test/index.html
@@ -91,7 +91,7 @@
 				scene3DOnly: true, // 只渲染 3D，节省资源
 				imageryProviderViewModels,
 				// terrainProviderViewModels,
-				selectedImageryProviderViewModel: imageryProviderViewModels[0],
+				selectedImageryProviderViewModel: imageryProviderViewModels[2],
 				// selectedTerrainProviderViewModel: terrainProviderViewModels[0],
 				terrainProvider: Cesium.createWorldTerrain(),
 			})


### PR DESCRIPTION
原来的天地图代码由于固定使用t0子域, 导致请求过多时会返回错误码被禁止访问. 
由于WebMapTileServiceImageryProvider构造函数url参数使用{s}占位符会导致剩余参数请求时消失, 所以现临时使用随机数拼接解决.